### PR TITLE
Include parameter descriptions in extracted inputs

### DIFF
--- a/runner/arazzo_runner/extractor/openapi_extractor.py
+++ b/runner/arazzo_runner/extractor/openapi_extractor.py
@@ -318,10 +318,14 @@ def extract_operation_io(
             # Add to properties as { 'type': 'openapi_type_string' }
             # Required status will be tracked in the top-level 'required' list
             is_required = param.get('required', False) # Default to false if not present
-            extracted_details["inputs"]["properties"][param_name] = {
+            param_input = {
                 "type": openapi_type
-                # Removed "required": is_required from here
             }
+            # Add description if it exists
+            param_description = param.get('description')
+            if param_description:
+                param_input["description"] = param_description
+            extracted_details["inputs"]["properties"][param_name] = param_input
             if is_required:
                 # Add to top-level required list if not already present
                 if param_name not in extracted_details["inputs"]["required"]:

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arazzo_runner"
-version = "0.8.14"
+version = "0.8.15"
 description = "Execution libraries and test tools for Arazzo workflows and Open API operations"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},

--- a/runner/tests/extractor/test_openapi_extractor.py
+++ b/runner/tests/extractor/test_openapi_extractor.py
@@ -39,6 +39,7 @@ TEST_SPEC = {
                         "name": "X-Request-ID",
                         "in": "header",
                         "required": False,
+                        "description": "Request identifier for tracing",
                         "schema": {"type": "string", "format": "uuid"}
                     }
                 ],
@@ -76,7 +77,7 @@ TEST_SPEC = {
                  "type": "object",
                  "properties": {
                      "items": {"type": "array", "items": {"$ref": "#/components/schemas/OrderItem"}},
-                     "customer_notes": {"type": "string"}
+                     "customer_notes": {"type": "string", "description": "Additional notes from the customer"}
                  }
              },
             "OrderItem": {
@@ -169,8 +170,8 @@ def test_extract_order_post_details():
 
     # Check non-body parameter (simplified schema within properties)
     assert "X-Request-ID" in input_properties
-    # Check type only, required status is in the top-level list
-    assert input_properties["X-Request-ID"] == {"type": "string"}
+    # Check type and description, required status is in the top-level list
+    assert input_properties["X-Request-ID"] == {"type": "string", "description": "Request identifier for tracing"}
     # Check that it's NOT required in the top-level list
     assert "X-Request-ID" not in extracted["inputs"].get("required", [])
 
@@ -193,7 +194,7 @@ def test_extract_order_post_details():
 
     # Check the flattened 'customer_notes' property from the body
     assert "customer_notes" in input_properties
-    assert input_properties["customer_notes"] == {"type": "string"}
+    assert input_properties["customer_notes"] == {"type": "string", "description": "Additional notes from the customer"}
 
     # Check required properties from the body are in the top-level required list
     # 'items' is NOT listed in the requestBody schema's top-level required list in TEST_SPEC


### PR DESCRIPTION
Adds parameter descriptions from OpenAPI specs to extracted inputs. Descriptions are preserved for regular parameters and request body properties when available.