### PR TITLE
ci(test): run workflow on main branch or during PR only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
This change optimizes the spending of action minutes by limiting workflow run on `main` branch only. If we find out that developers are using long living branches and require CI feedback before making PR, we'll need to modify the `push` trigger. 