### PR TITLE
fix: fix local file path security issues 

### DIFF
--- a/generator/.env.example
+++ b/generator/.env.example
@@ -1,0 +1,30 @@
+# .env Template - API Key Management
+# -----------------------------------------------------------------------------
+# HOW TO USE
+# 1) Make a real env file from this template:
+#    • macOS/Linux:            cp .env.example .env
+#    • Windows (PowerShell):   Copy-Item .env.example .env
+#    • Windows (CMD):          copy .env.example .env
+#    Or create a new `.env` and paste this entire content into it.
+#
+# 2) Fill in the values below. Empty strings ("") mean that provider/feature is
+#    disabled locally.
+#
+# 3) Restart your dev server/tooling after edits so the new env vars load.
+#
+# SECURITY & VERSION CONTROL
+# • Never commit real secrets—keep them only in your local `.env` and in your
+#   deployment platform’s secret manager (e.g., GitHub Actions Secrets, Vercel/
+#   Netlify env, Docker `--env-file`, Kubernetes Secrets).
+# • Ensure `.gitignore` contains a line with:  .env
+# -----------------------------------------------------------------------------
+
+# API KEYS (Optional: enable one or more providers)
+GEMINI_API_KEY="your_gemini_api_key_here"             # Optional (Recommended), for Google Gemini models.
+ANTHROPIC_API_KEY="your_anthropic_api_key_here"       # Optional: for Anthropic models
+OPENAI_API_KEY="your_openai_api_key_here"             # Optional, for OpenAI/OpenRouter models.
+
+# Find more information on supported providers using LiteLLM (https://docs.litellm.ai/docs/providers)
+
+# Set the path to the repository containing OpenAPI specs for local file paths: 
+OPENAPI_SPECS_DIR=/Users/example-user/example-project/

--- a/generator/README.md
+++ b/generator/README.md
@@ -72,6 +72,28 @@ export ANTHROPIC_API_KEY=your_anthropic_key_here
 export OPENAI_API_KEY=your_openai_key_here
 ```
 
+### Handling Local OpenAPI Specifications
+
+When working with local OpenAPI specification files that contain relative references (`$ref`) to other local files, you must set the `OPENAPI_SPECS_DIR` environment variable. This is a security measure to ensure that the generator only accesses files within a trusted directory.
+
+Set the variable to the absolute path of the root directory containing your OpenAPI specifications.
+
+**Example:**
+
+If your specs are in `/Users/me/example-project/apis/`, you would set the variable like this:
+
+```bash
+export OPENAPI_SPECS_DIR=/Users/me/example-project/apis/
+```
+
+Or in a `.env` file:
+
+```bash
+OPENAPI_SPECS_DIR=/Users/me/example-project/apis/
+```
+
+**Note:** The generator will then be able to safely resolve any relative references within that directory.
+
 ## Usage
 
 ### Basic Usage
@@ -290,4 +312,3 @@ This Arazzo Generator powers the automated workflow generation in the [jentic-pu
 3. Optionally, specify any specific workflows you'd like to generate
 
 The system will automatically process your request and generate the corresponding Arazzo specification. You'll be notified when the generation is complete.
-

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import re
+import json
 from typing import Any, Dict
 from urllib.parse import urlparse
 

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -74,12 +74,12 @@ class OpenAPIParser:
             else:
                 # For local files (bare path or file://), validate the path first.
                 local_path = pathlib.Path(parsed_url.path) if parsed_url.scheme == "file" else pathlib.Path(self.url)
+                resolved_path = local_path.resolve()
 
-                if not is_within_safe_roots(local_path):
-                    logger.error(f"Attempted access to file outside of safe root: {local_path}")
+                if not is_within_safe_roots(resolved_path):
+                    logger.error(f"Attempted access to file outside of safe root: {resolved_path}")
                     raise ValueError("Access to files outside the allowed directory is not permitted.")
 
-                resolved_path = local_path.resolve()
                 prance_url = resolved_path.as_uri()
 
                 try:

--- a/generator/arazzo_generator/security/safe_paths.py
+++ b/generator/arazzo_generator/security/safe_paths.py
@@ -31,6 +31,14 @@ def is_within_safe_roots(path: str | pathlib.Path) -> bool:
     """Check if a given path is within one of the configured safe roots."""
     try:
         resolved_path = pathlib.Path(path).resolve(strict=True)
-        return any(resolved_path.is_relative_to(root) for root in SAFE_ROOTS)
+        for root in SAFE_ROOTS:
+            root_resolved = root.resolve(strict=True)
+            # Compare with explicit boundary check (Path.relative_to throws if not inside)
+            try:
+                resolved_path.relative_to(root_resolved)
+                return True
+            except ValueError:
+                continue
+        return False
     except (ValueError, FileNotFoundError):
         return False

--- a/generator/arazzo_generator/security/safe_paths.py
+++ b/generator/arazzo_generator/security/safe_paths.py
@@ -1,0 +1,36 @@
+"""Safe path handling for the Arazzo generator."""
+
+import os
+import pathlib
+
+# The project root is always considered a safe directory for local file access.
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SAFE_ROOTS = [PROJECT_ROOT]
+
+def _is_filesystem_root(path: pathlib.Path) -> bool:
+    """Check if the given path is a filesystem root."""
+    # A path is a root if it's absolute and has only one part (e.g., '/' or 'C:\').
+    return path.is_absolute() and len(path.parts) == 1
+
+def add_external_root():
+    """Add an external safe directory from an environment variable if it's valid."""
+    external_dir = os.environ.get("OPENAPI_SPECS_DIR")
+    if not external_dir:
+        return
+
+    try:
+        external_path = pathlib.Path(external_dir).resolve(strict=True)
+        if _is_filesystem_root(external_path):
+            raise ValueError("Filesystem root directories are not allowed as external spec roots.")
+        SAFE_ROOTS.append(external_path)
+    except (FileNotFoundError, ValueError) as e:
+        # Silently ignore invalid or non-existent directories.
+        print(f"Warning: Invalid OPENAPI_SPECS_DIR: {e}")
+
+def is_within_safe_roots(path: str | pathlib.Path) -> bool:
+    """Check if a given path is within one of the configured safe roots."""
+    try:
+        resolved_path = pathlib.Path(path).resolve(strict=True)
+        return any(resolved_path.is_relative_to(root) for root in SAFE_ROOTS)
+    except (ValueError, FileNotFoundError):
+        return False

--- a/generator/tests/parser/test_openapi_parser.py
+++ b/generator/tests/parser/test_openapi_parser.py
@@ -1,11 +1,12 @@
 """Tests for the OpenAPI parser module."""
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from arazzo_generator.parser.openapi_parser import OpenAPIParser
 
 
+@patch('prance.util.url.requests.get')
 class TestOpenAPIParser(unittest.TestCase):
     """Tests for the OpenAPIParser class."""
 
@@ -14,8 +15,7 @@ class TestOpenAPIParser(unittest.TestCase):
         # Reset any class variables or state before each test
         pass
 
-    @patch.object(OpenAPIParser, "_fetch_and_parse_with_fallbacks")
-    def test_fetch_spec_json(self, mock_fetch):
+    def test_fetch_spec_json(self, mock_requests_get):
         """Test fetching a JSON OpenAPI spec."""
         # Prepare test data
         test_spec = {
@@ -32,7 +32,10 @@ class TestOpenAPIParser(unittest.TestCase):
         }
 
         # Configure the mock to return our test data
-        mock_fetch.return_value = test_spec
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = test_spec
+        mock_requests_get.return_value = mock_response
 
         # Create parser and fetch spec
         parser = OpenAPIParser("https://example.com/openapi.json")
@@ -47,8 +50,7 @@ class TestOpenAPIParser(unittest.TestCase):
         self.assertEqual(parser.version, "3.0.0")
         self.assertIn("/test", parser.paths)
 
-    @patch.object(OpenAPIParser, "_fetch_and_parse_with_fallbacks")
-    def test_fetch_spec_yaml(self, mock_fetch):
+    def test_fetch_spec_yaml(self, mock_requests_get):
         """Test fetching a YAML OpenAPI spec."""
         # Prepare test data
         test_spec = {
@@ -65,7 +67,10 @@ class TestOpenAPIParser(unittest.TestCase):
         }
 
         # Configure the mock to return our test data
-        mock_fetch.return_value = test_spec
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = test_spec
+        mock_requests_get.return_value = mock_response
 
         # Create parser and fetch spec
         parser = OpenAPIParser("https://example.com/openapi.yaml")
@@ -76,8 +81,7 @@ class TestOpenAPIParser(unittest.TestCase):
         self.assertEqual(spec["info"]["title"], "Test API")
         self.assertEqual(spec["paths"]["/test"]["get"]["operationId"], "getTest")
 
-    @patch.object(OpenAPIParser, "_fetch_and_parse_with_fallbacks")
-    def test_get_endpoints(self, mock_fetch):
+    def test_get_endpoints(self, mock_requests_get):
         """Test getting endpoints from the OpenAPI spec."""
         # Prepare test data with endpoints
         test_spec = {
@@ -112,11 +116,14 @@ class TestOpenAPIParser(unittest.TestCase):
         }
 
         # Configure the mock to return our test data
-        mock_fetch.return_value = test_spec
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = test_spec
+        mock_requests_get.return_value = mock_response
 
         # Create a new parser instance for this test
         parser = OpenAPIParser("https://example.com/openapi.json")
-        parser.fetch_spec()  # This will use the mock
+        # fetch_spec() is called within get_endpoints() if spec is not present
 
         # Get endpoints
         endpoints = parser.get_endpoints()
@@ -130,8 +137,7 @@ class TestOpenAPIParser(unittest.TestCase):
         self.assertEqual(len(endpoints["/users"]["get"]["parameters"]), 1)
         self.assertEqual(endpoints["/users"]["get"]["parameters"][0]["name"], "limit")
 
-    @patch.object(OpenAPIParser, "_fetch_and_parse_with_fallbacks")
-    def test_get_schemas(self, mock_fetch):
+    def test_get_schemas(self, mock_requests_get):
         """Test getting schemas from the OpenAPI spec."""
         # Prepare test data with schemas
         test_spec = {
@@ -152,11 +158,14 @@ class TestOpenAPIParser(unittest.TestCase):
         }
 
         # Configure the mock to return our test data
-        mock_fetch.return_value = test_spec
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = test_spec
+        mock_requests_get.return_value = mock_response
 
         # Create a new parser instance for this test
         parser = OpenAPIParser("https://example.com/openapi.json")
-        parser.fetch_spec()  # This will use the mock
+        # fetch_spec() is called within get_schemas() if spec is not present
 
         # Get schemas
         schemas = parser.get_schemas()
@@ -167,8 +176,7 @@ class TestOpenAPIParser(unittest.TestCase):
         self.assertIn("id", schemas["User"]["properties"])
         self.assertIn("name", schemas["User"]["properties"])
 
-    @patch.object(OpenAPIParser, "_fetch_and_parse_with_fallbacks")
-    def test_get_security_schemes(self, mock_fetch):
+    def test_get_security_schemes(self, mock_requests_get):
         """Test getting security schemes from the OpenAPI spec."""
         # Prepare test data with security schemes
         test_spec = {
@@ -187,11 +195,14 @@ class TestOpenAPIParser(unittest.TestCase):
         }
 
         # Configure the mock to return our test data
-        mock_fetch.return_value = test_spec
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = test_spec
+        mock_requests_get.return_value = mock_response
 
         # Create a new parser instance for this test
         parser = OpenAPIParser("https://example.com/openapi.json")
-        parser.fetch_spec()  # This will use the mock
+        # fetch_spec() is called within get_security_schemes() if spec is not present
 
         # Get security schemes
         security_schemes = parser.get_security_schemes()

--- a/generator/tests/security/test_safe_paths.py
+++ b/generator/tests/security/test_safe_paths.py
@@ -1,0 +1,75 @@
+"""Tests for the safe_paths module."""
+
+import os
+import pathlib
+import tempfile
+from unittest import mock
+
+import pytest
+
+from arazzo_generator.security import safe_paths
+
+
+@pytest.fixture(autouse=True)
+def reset_safe_roots():
+    """Fixture to reset SAFE_ROOTS to its initial state before each test."""
+    original_roots = list(safe_paths.SAFE_ROOTS)
+    yield
+    safe_paths.SAFE_ROOTS = original_roots
+
+
+def test_project_root_is_safe():
+    """Test that a path within the project root is considered safe."""
+    assert safe_paths.is_within_safe_roots(safe_paths.PROJECT_ROOT / "README.md")
+
+
+def test_external_directory_is_safe():
+    """Test that a path within a configured external directory is safe."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        external_path = pathlib.Path(tmpdir)
+        (external_path / "test.json").touch()
+
+        with mock.patch.dict(os.environ, {"OPENAPI_SPECS_DIR": str(external_path)}):
+            safe_paths.add_external_root()
+            assert safe_paths.is_within_safe_roots(external_path / "test.json")
+
+
+def test_unsafe_directory_is_not_safe():
+    """Test that a path outside of any safe root is not considered safe."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        unsafe_path = pathlib.Path(tmpdir) / "unsafe.json"
+        unsafe_path.touch()
+        assert not safe_paths.is_within_safe_roots(unsafe_path)
+
+
+def test_parent_directory_traversal_is_not_safe():
+    """Test that a path attempting directory traversal is not safe."""
+    # This path will resolve outside the project root.
+    unsafe_path = safe_paths.PROJECT_ROOT / ".." / "some_other_file.txt"
+    assert not safe_paths.is_within_safe_roots(unsafe_path)
+
+
+@pytest.mark.parametrize(
+    "root_path_str",
+    [
+        "/",  # Unix root
+        "C:\\",  # Windows root
+    ],
+)
+def test_filesystem_roots_are_not_allowed(capsys, root_path_str):
+    """Test that setting various filesystem roots as the external directory is rejected."""
+    root_dir = pathlib.Path(root_path_str)
+    with mock.patch.dict(os.environ, {"OPENAPI_SPECS_DIR": str(root_dir)}):
+        safe_paths.add_external_root()
+        captured = capsys.readouterr()
+        assert "Warning: Invalid OPENAPI_SPECS_DIR" in captured.out
+        assert root_dir not in safe_paths.SAFE_ROOTS
+
+
+def test_non_existent_external_dir_is_ignored(capsys):
+    """Test that a non-existent external directory is safely ignored."""
+    non_existent_path = "/path/that/does/not/exist"
+    with mock.patch.dict(os.environ, {"OPENAPI_SPECS_DIR": non_existent_path}):
+        safe_paths.add_external_root()
+        captured = capsys.readouterr()
+        assert "Warning: Invalid OPENAPI_SPECS_DIR" in captured.out


### PR DESCRIPTION
This PR handles a first pass approach at fixing security issues flagged by CodeQL for the arazzo generator. 

"Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files."

When using local files the path must resolve to a safe root. When using the generator locally this can be set in the .env by OPENAPI_SPEC_DIR=/Users/example-user/example-project/  to the repo where the OpenAPI specs are stored. This will then allow the user to input the url correctly and safely using the pdm run generate function for a local URL. 

