### PR TITLE
fix(generator): eliminate catastrophic backtracking vulnerability in parser

### DIFF
--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -279,7 +279,7 @@ class OpenAPIParser:
             # 1) key: <non-empty value>  ->  "key": "value",
             json_like = re.sub(
                 r"^(?P<i>[ \t]*)(?P<k>[A-Za-z0-9_-]+):[ \t]*(?P<v>\S[^\n]*?)(?=[ \t]*$)",
-                lambda m: f'{m.group("i")}"{m.group("k")}": "{m.group("v")}",',
+                r'\g<i>"\g<k>": "\g<v>",',
                 json_like,
                 flags=re.MULTILINE,
             )

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -277,7 +277,7 @@ class OpenAPIParser:
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
             json_like = re.sub(
-                r"^(\s*)([\w\-]+):\s+(.*\S)\s*$",
+                r"^(\s*)([\w\-]+):\s*([^\s].*?)\s*$",
                 r'\1"\2": "\3",',
                 json_like,
                 flags=re.MULTILINE,

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -277,7 +277,7 @@ class OpenAPIParser:
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
             json_like = re.sub(
-                r"^(\s*)([\w\-]+):\s*(.*\S)?\s*$",
+                r"^(\s*)([\w\-]+):\s+(.*\S)\s*$",
                 r'\1"\2": "\3",',
                 json_like,
                 flags=re.MULTILINE,

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -276,17 +276,17 @@ class OpenAPIParser:
             # Very simplistic YAML to JSON conversion (only handles basic structures)
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
-            # 1) key: <non-empty value (even spaces)> -> "key": "value",
+            # 1) "key": "value",
             json_like = re.sub(
-                r"^(?P<i>[ \t]*)(?P<k>[\w-]+):[ \t]*(?P<v>[^\n][^\n]*?)(?=[ \t]*$)",
+                r"^(?P<i>[^\S\n]*)(?P<k>[\w-]+):[^\S\n]*(?P<v>[^\n][^\n]*?)(?=[^\S\n]*$)",
                 r'\g<i>"\g<k>": "\g<v>",',
                 json_like,
                 flags=re.MULTILINE,
             )
 
-            # 2) key: <empty> -> "key": {
+            # key: -> "key": {
             json_like = re.sub(
-                r"^(?P<i>[ \t]*)(?P<k>[\w-]+):[ \t]*$",
+                r"^(?P<i>[^\S\n]*)(?P<k>[\w-]+):[^\S\n]*$",
                 r'\g<i>"\g<k>": {',
                 json_like,
                 flags=re.MULTILINE,

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -277,15 +277,17 @@ class OpenAPIParser:
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
             # 1) key: <non-empty value>  ->  "key": "value",
+            # 1) key: <non-empty value (even spaces)> -> "key": "value",
             json_like = re.sub(
-                r"^(?P<i>[ \t]*)(?P<k>[A-Za-z0-9_-]+):[ \t]*(?P<v>\S[^\n]*?)(?=[ \t]*$)",
+                r"^(?P<i>[ \t]*)(?P<k>[\w-]+):[ \t]*(?P<v>[^\n][^\n]*?)(?=[ \t]*$)",
                 r'\g<i>"\g<k>": "\g<v>",',
                 json_like,
                 flags=re.MULTILINE,
             )
-            # 2) key: <empty>            ->  "key": {
+
+            # 2) key: <empty> -> "key": {
             json_like = re.sub(
-                r"^(?P<i>[ \t]*)(?P<k>[A-Za-z0-9_-]+):[ \t]*$",
+                r"^(?P<i>[ \t]*)(?P<k>[\w-]+):[ \t]*$",
                 r'\g<i>"\g<k>": {',
                 json_like,
                 flags=re.MULTILINE,

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -277,8 +277,8 @@ class OpenAPIParser:
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
             json_like = re.sub(
-                r"^(\s*)([\w\-]+):\s*([^\s].*?)\s*$",
-                r'\1"\2": "\3",',
+                r"^(\s*)([\w\-]+):\s*(.+?)$",
+                lambda m: f'{m.group(1)}"{m.group(2)}": "{m.group(3).rstrip()}",',
                 json_like,
                 flags=re.MULTILINE,
             )

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -277,7 +277,7 @@ class OpenAPIParser:
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
             json_like = re.sub(
-                r"^(\s*)([\w\-]+):\s*(.+?)\s*$",
+                r"^(\s*)([\w\-]+):\s*(.*\S)?\s*$",
                 r'\1"\2": "\3",',
                 json_like,
                 flags=re.MULTILINE,

--- a/generator/arazzo_generator/parser/openapi_parser.py
+++ b/generator/arazzo_generator/parser/openapi_parser.py
@@ -276,7 +276,6 @@ class OpenAPIParser:
             # Very simplistic YAML to JSON conversion (only handles basic structures)
             # Replace YAML indentation with JSON nesting
             json_like = cleaned_content
-            # 1) key: <non-empty value>  ->  "key": "value",
             # 1) key: <non-empty value (even spaces)> -> "key": "value",
             json_like = re.sub(
                 r"^(?P<i>[ \t]*)(?P<k>[\w-]+):[ \t]*(?P<v>[^\n][^\n]*?)(?=[ \t]*$)",


### PR DESCRIPTION
Usefulness of this self-correcting mechanism is questionable - should we really try to correct unparsable OpenAPI files? The goal of this change was to make it at least a bit secure, but the question remains? Should we do this at all (question for future)?