### PR TITLE
ci: consolidate enforcing of code consistency

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -49,9 +49,8 @@ generate = "python -m arazzo_generator.cli.run generate"
 batch = "python -m arazzo_generator.cli.run batch"
 api = "python -m arazzo_generator.api.run"
 test = "pytest"
-format = {cmd = "bash -c 'black arazzo_generator/ tests/ && isort arazzo_generator/ tests/'"}
-check-format = {cmd = "bash -c 'black --check arazzo_generator/ tests/ && isort --check-only arazzo_generator/ tests/ || exit 0'"}
-lint = {composite = ["black .", "isort .", "ruff check ."]}
+lint = {composite = ["black --check .", "isort --check-only .", "ruff check ."]}
+"lint:fix" = {composite = ["ruff check . --fix", "black .", "isort ."]}
 typecheck = "mypy ."
 
 [tool.setuptools.packages.find]

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -26,7 +26,8 @@ build-backend = "pdm.backend"
 
 [tool.pdm]
 [tool.pdm.scripts]
-lint = {composite = ["black .", "isort .", "ruff check ."]}
+lint = {composite = ["black --check .", "isort --check-only .", "ruff check ."]}
+"lint:fix" = {composite = [ "ruff check . --fix", "black .", "isort ."]}
 typecheck = "mypy ."
 test = "pytest"
 test-real = "python -m tests.run_real_tests"


### PR DESCRIPTION
We now have two simple scripts: `pdm run lint` and `pdm run lint:fix`


- `pdm run lint` doesn't perform any code mutations only checks for code consistency
- `pdm run lint:fix` performs code mutations and fixes what it can. `ruff` is run first before other tooling as that is what the documentation recommends