### PR TITLE
fix(generator): allow generator CLI to run

### DIFF
--- a/generator/arazzo_generator/__main__.py
+++ b/generator/arazzo_generator/__main__.py
@@ -1,0 +1,6 @@
+from .cli import main as run_main
+
+__all__ = ["run_main"]
+
+if __name__ == "__main__":
+    run_main()


### PR DESCRIPTION
Refs #76

---

Generator CLI was not working at all. The PR provides complete remediation. With this fix it would now be possible to run

```bash
$ uxv arazzo-generator --help
```

Or locally

```bash
$ cd generator
$ python -m arazzo_generator --help
# or just
$ arazzo-generator --help
```
