### PR TITLE
chore(release): cut the arazzo_generator v0.1.2 release

### DIFF
--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arazzo_generator"
-version = "0.1.1"
+version = "0.1.2"
 description = "Tool for analyzing OpenAPI specifications and generating meaningful Arazzo workflows by identifying logical API sequences and patterns."
 authors = [
     {name = "Jentic", email = "hello@jentic.com"},


### PR DESCRIPTION
Release will be done according to https://github.com/jentic/arazzo-engine/issues/65