### PR TITLE
fix: enforce retryLimit and correct step pointer on retry

### DIFF
--- a/runner/arazzo_runner/executor/action_handler.py
+++ b/runner/arazzo_runner/executor/action_handler.py
@@ -126,20 +126,18 @@ class ActionHandler:
                     retry_limit = action.get("retryLimit", 1)
 
                     # Enforce retry limit using a counter stored on the execution state.
-                    if not hasattr(state, "_retry_counts"):
-                        state._retry_counts = {}
-                    current_count = state._retry_counts.get(step_id, 0)
+                    current_count = state.retry_counts.get(step_id, 0)
 
                     if current_count >= retry_limit:
                         # Limit exhausted — clear counter and fall through to next action.
-                        state._retry_counts.pop(step_id, None)
+                        state.retry_counts.pop(step_id, None)
                         logger.info(
                             f"Retry limit {retry_limit} exhausted for step {step_id}, "
                             "processing next failure action"
                         )
                         continue
 
-                    state._retry_counts[step_id] = current_count + 1
+                    state.retry_counts[step_id] = current_count + 1
                     logger.info(
                         f"Failure action {action_name} retry {current_count + 1}/{retry_limit} "
                         f"(after={retry_after})"

--- a/runner/arazzo_runner/executor/action_handler.py
+++ b/runner/arazzo_runner/executor/action_handler.py
@@ -124,8 +124,25 @@ class ActionHandler:
                 elif action_type == "retry":
                     retry_after = action.get("retryAfter", 0)
                     retry_limit = action.get("retryLimit", 1)
+
+                    # Enforce retry limit using a counter stored on the execution state.
+                    if not hasattr(state, "_retry_counts"):
+                        state._retry_counts = {}
+                    current_count = state._retry_counts.get(step_id, 0)
+
+                    if current_count >= retry_limit:
+                        # Limit exhausted — clear counter and fall through to next action.
+                        state._retry_counts.pop(step_id, None)
+                        logger.info(
+                            f"Retry limit {retry_limit} exhausted for step {step_id}, "
+                            "processing next failure action"
+                        )
+                        continue
+
+                    state._retry_counts[step_id] = current_count + 1
                     logger.info(
-                        f"Failure action {action_name} retries (after={retry_after}, limit={retry_limit})"
+                        f"Failure action {action_name} retry {current_count + 1}/{retry_limit} "
+                        f"(after={retry_after})"
                     )
 
                     result = {

--- a/runner/arazzo_runner/models.py
+++ b/runner/arazzo_runner/models.py
@@ -88,6 +88,7 @@ class ExecutionState:
     dependency_outputs: dict[str, dict[str, Any]] = None
     status: dict[str, StepStatus] = None
     runtime_params: Optional["RuntimeParams"] = None
+    retry_counts: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self):
         """Initialize default values"""

--- a/runner/arazzo_runner/runner.py
+++ b/runner/arazzo_runner/runner.py
@@ -569,11 +569,12 @@ class ArazzoRunner:
                         "step_id": next_action["step_id"],
                     }
             elif next_action["type"] == ActionType.RETRY:
-                # Retry the current step
-                # We don't change the step_id so it will retry on next execution
+                # Retry the current step.
+                # Set goto_step_id so the next execute_next_step call re-executes
+                # this step directly instead of advancing to current_step_id + 1.
                 state.status[step_id] = StepStatus.PENDING
+                state.goto_step_id = step_id
 
-                # If there's a delay, we should return that information
                 retry_delay = next_action.get("retry_after", 0)
                 return {
                     "status": WorkflowExecutionStatus.RETRY,

--- a/runner/arazzo_runner/runner.py
+++ b/runner/arazzo_runner/runner.py
@@ -489,6 +489,10 @@ class ArazzoRunner:
             # Update step status
             state.status[step_id] = StepStatus.SUCCESS if success else StepStatus.FAILURE
 
+            # Clear retry count for this step on success so re-visits start fresh.
+            if success:
+                state.retry_counts.pop(step_id, None)
+
             # Store step outputs
             state.step_outputs[step_id] = step_result.get("outputs", {})
 


### PR DESCRIPTION
## Summary
This PR addresses **#141** by fixing the logic that caused the runner to skip retries and advance to the next step prematurely.

## Changes
- **Runner Loop Fix:** In `runner.py`, we now set `state.goto_step_id` to the current step ID when a retry is requested. This forces the execution loop to re-run the same step rather than advancing.
- **Retry Limit Enforcement:** In `action_handler.py`, I added a `_retry_counts` map to the `ExecutionState` to track attempts. The handler now honors `retryLimit` and falls through to the next failure action (e.g., `end` or `goto`) once the limit is hit.

## Verification
- Verified against a local Arazzo test workflow where a step intentionally fails, retries up to its limit, and correctly falls back to an `end` action.
- Ran the existing `pytest` test suite.
  - **Results:** `1 failed, 310 passed, 8 skipped, 2 warnings in 4.06s`
  - **Note:** The 1 failure (`test_fixture_discovery.py::Test_spotify::test_workflows - AssertionError:`). This failure is unrelated to the retry fix and was present in the baseline runner as well.

Closes #141